### PR TITLE
Add GitHub Actions workflow for FBI Most Wanted updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Update FBI Most Wanted Data
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # Run every 15 minutes
+  workflow_dispatch:  # Allows manual trigger for testing
+
+jobs:
+  update-fbi-data:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        
+    - name: Create directories
+      run: mkdir -p data
+        
+    - name: Run FBI data updater
+      run: python scripts/update_fbi_data.py
+      env:
+        TRMNL_API_KEY: ${{ secrets.TRMNL_API_KEY }}
+        TRMNL_PLUGIN_UUID: ${{ secrets.TRMNL_PLUGIN_UUID }}
+        
+    - name: Commit and push if there are changes
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add data/
+        git commit -m "Update FBI Most Wanted data" || exit 0
+        git push


### PR DESCRIPTION
Switching from Render to GitHub Actions to handle FBI Most Wanted data updates. This workflow will:
- Run every 15 minutes
- Fetch new FBI data
- Update TRMNL display
- Store data and images in repository